### PR TITLE
Adjustments of sd example to 5.11

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,7 +8,10 @@
 #include "platform/mbed_retarget.h"
 
 
-SDBlockDevice sd(MBED_CONF_APP_SPI_MOSI, MBED_CONF_APP_SPI_MISO, MBED_CONF_APP_SPI_CLK, MBED_CONF_APP_SPI_CS);
+SDBlockDevice sd(MBED_CONF_SD_SPI_MOSI, 
+				 MBED_CONF_SD_SPI_MISO, 
+				 MBED_CONF_SD_SPI_CLK, 
+				 MBED_CONF_SD_SPI_CS);
 FATFileSystem fs("sd", &sd);
 
 void return_error(int ret_val){

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#f4864dc6429e1ff5474111d4e0f6bee36a759b1c
+https://github.com/ARMmbed/mbed-os/#3fb5781af180c32a6062f050d59cdf93654b3e9f

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3fb5781af180c32a6062f050d59cdf93654b3e9f
+https://github.com/ARMmbed/mbed-os/#a8f0c33eaa2c52babff9655417c36f4b5edd54d7

--- a/sd-driver.lib
+++ b/sd-driver.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/sd-driver/#96142e4303df6540b4b231453dd23701111dc1bb


### PR DESCRIPTION
Removing sd-driver.lib file, updating mbed-os.lib to mbed-os-5.11.2 tag version.
@adbridge @ashok-rao